### PR TITLE
put() for TimeEntries

### DIFF
--- a/TogglPy.py
+++ b/TogglPy.py
@@ -165,6 +165,17 @@ class Toggl():
         response = self.postRequest(Endpoints.TIME_ENTRIES, parameters=data)
         return self.decodeJSON(response)
 
+    def putTimeEntry(self, parameters):
+        if not 'id' in parameters:
+            raise Exception("An id must be provided in order to put a time entry")
+        id = parameters['id']
+        endpoint = Endpoints.TIME_ENTRIES  + "/" + str(id) # encode all of our data for a get request & modify the URL
+        data = json.JSONEncoder().encode({'time_entry': parameters})
+        request = urllib2.Request(endpoint, data=data, headers=self.headers)
+        request.get_method = lambda:"PUT"
+
+        return json.loads(urllib2.urlopen(request).read())
+
     #-----------------------------------
     # Methods for getting workspace data
     #-----------------------------------

--- a/TogglPy.py
+++ b/TogglPy.py
@@ -169,7 +169,9 @@ class Toggl():
         if not 'id' in parameters:
             raise Exception("An id must be provided in order to put a time entry")
         id = parameters['id']
-        endpoint = Endpoints.TIME_ENTRIES  + "/" + str(id) # encode all of our data for a get request & modify the URL
+        if type(id) is not int:
+            raise Exception("Invalid id %s provided " % ( id ) )
+        endpoint = Endpoints.TIME_ENTRIES  + "/" + str(id) # encode all of our data for a put request & modify the URL
         data = json.JSONEncoder().encode({'time_entry': parameters})
         request = urllib2.Request(endpoint, data=data, headers=self.headers)
         request.get_method = lambda:"PUT"


### PR DESCRIPTION
I added a public put() method for the timesheet entries.  My use case was doing pattern matching on projects that hadn't been booked to a client.project, for example the 'Pomodoro Break' entry that is auto-created by Toggl when Pomodoro mode is turned on. 