### PR TITLE
Added a method to return all projects in a workspace

### DIFF
--- a/toggl/TogglPy.py
+++ b/toggl/TogglPy.py
@@ -243,9 +243,19 @@ class Toggl():
                     return workspace  # if we find it return it
             return None  # if we get to here and haven't found it return None
 
+    def getWorkspaceProjects(self, id):
+        """
+        Return all of the projects for a given Workspace
+        :param id: Workspace ID by which to query
+        :return: Projects object returned from endpoint
+        """
+
+        return self.request(Endpoints.WORKSPACES + '/{0}'.format(id) + '/projects')
+
     # -------------------------------
     # Methods for getting client data
     # -------------------------------
+
     def getClients(self):
         '''return all clients that are visable to a user'''
         return self.request(Endpoints.CLIENTS)

--- a/toggl/documentation.md
+++ b/toggl/documentation.md
@@ -53,7 +53,13 @@ CLASSES
      |  
      |  getWorkspaces(self)
      |      return all the workspaces for a user
-     |  
+     |
+     |  getDetailedReportPages(self, data)
+     |      return detailed report data from all pages for a user
+     |
+     |  getWorkspaceProjects(self, id)
+     |      return all of the projects for a given Workspace
+     |
      |  request(self, endpoint, parameters=None)
      |      make a request to the toggle api at a certain endpoint and return the page data as a parsed JSON dict
      |  


### PR DESCRIPTION
Hi,

I've added an additional method, getWorkspaceProjects(),  which will return all projects registered to a workspace.

I've also added this method to the documentation.md, along with the details for the recently added getDetailedReportPages() method.