### PR TITLE
[Feature] Additional client methods

### DIFF
--- a/toggl/TogglPy.py
+++ b/toggl/TogglPy.py
@@ -437,3 +437,23 @@ class Toggl():
         # write the data to a file
         with open(filename, "wb") as pdf:
             pdf.write(filedata)
+
+    # --------------------------------
+    # Methods for creating and updating clients
+    # ---------------------------------
+    def createClient(self, name, wid, notes=None):
+        """
+        create a new client
+        :param name: Name the client
+        :param wid: Workspace ID
+        :param notes: Notes for the client (optional)
+        """
+
+        data = {}
+        data['client'] = {}
+        data['client']['name'] = name
+        data['client']['wid'] = wid
+        data['client']['notes'] = notes
+
+        response = self.postRequest(Endpoints.CLIENTS, parameters=data)
+        return self.decodeJSON(response)

--- a/toggl/TogglPy.py
+++ b/toggl/TogglPy.py
@@ -112,8 +112,10 @@ class Toggl():
 
     def postRequest(self, endpoint, parameters=None, method='POST'):
         '''make a POST request to the toggle api at a certain endpoint and return the RAW page data (usually JSON)'''
+        if method == 'DELETE':  # Calls to the API using the DELETE mothod return a HTTP response rather than JSON
+            return urlopen(Request(endpoint, headers=self.headers, method=method), cafile=cafile).code
         if parameters is None:
-            return urlopen(Request(endpoint, headers=self.headers), cafile=cafile).read().decode('utf-8')
+            return urlopen(Request(endpoint, headers=self.headers, method=method), cafile=cafile).read().decode('utf-8')
         else:
             data = json.JSONEncoder().encode(parameters)
             binary_data = data.encode('utf-8')
@@ -439,7 +441,7 @@ class Toggl():
             pdf.write(filedata)
 
     # --------------------------------
-    # Methods for creating and updating clients
+    # Methods for creating, updating, and deleting clients
     # ---------------------------------
     def createClient(self, name, wid, notes=None):
         """
@@ -473,3 +475,11 @@ class Toggl():
 
         response = self.postRequest(Endpoints.CLIENTS + '/{0}'.format(id), parameters=data, method='PUT')
         return self.decodeJSON(response)
+
+    def deleteClient(self, id):
+        """
+        Delete the specified client
+        :param id: The id of the client to delete
+        """
+        response = self.postRequest(Endpoints.CLIENTS + '/{0}'.format(id), method='DELETE')
+        return response

--- a/toggl/TogglPy.py
+++ b/toggl/TogglPy.py
@@ -122,6 +122,15 @@ class Toggl():
                 Request(endpoint, data=binary_data, headers=self.headers), cafile=cafile
             ).read().decode('utf-8')
 
+    def putRequest(self, endpoint, parameters):
+        '''Make a PUT request to teh toggl api at a certain enpoint and return the RAW page data (usually JSON)'''
+        data = json.JSONEncoder().encode(parameters)
+        binary_data = data.encode('utf-8')
+        # make request and read the response
+        return urlopen(
+            Request(endpoint, data=binary_data, headers=self.headers, method='PUT'), cafile=cafile
+        ).read().decode('utf-8')
+
     # ---------------------------------
     # Methods for managing Time Entries
     # ---------------------------------
@@ -456,4 +465,20 @@ class Toggl():
         data['client']['notes'] = notes
 
         response = self.postRequest(Endpoints.CLIENTS, parameters=data)
+        return self.decodeJSON(response)
+
+    def updateClient(self, id, name=None, notes=None):
+        """
+        Update data for an existing client. If the name or notes parameter is not supplied, the existing data on the Toggl server will not be changed.
+        :param id: The id of the client to update
+        :param name: Update the name of the client (optional)
+        :param notes: Update the notes for the client (optional)
+        """
+
+        data = {}
+        data['client'] = {}
+        data['client']['name'] = name
+        data['client']['notes'] = notes
+
+        response = self.putRequest(Endpoints.CLIENTS + '/{0}'.format(id), parameters=data)
         return self.decodeJSON(response)

--- a/toggl/TogglPy.py
+++ b/toggl/TogglPy.py
@@ -110,7 +110,7 @@ class Toggl():
         '''make a request to the toggle api at a certain endpoint and return the page data as a parsed JSON dict'''
         return json.loads(self.requestRaw(endpoint, parameters).decode('utf-8'))
 
-    def postRequest(self, endpoint, parameters=None):
+    def postRequest(self, endpoint, parameters=None, method='POST'):
         '''make a POST request to the toggle api at a certain endpoint and return the RAW page data (usually JSON)'''
         if parameters is None:
             return urlopen(Request(endpoint, headers=self.headers), cafile=cafile).read().decode('utf-8')
@@ -119,17 +119,8 @@ class Toggl():
             binary_data = data.encode('utf-8')
             # make request and read the response
             return urlopen(
-                Request(endpoint, data=binary_data, headers=self.headers), cafile=cafile
+                Request(endpoint, data=binary_data, headers=self.headers, method=method), cafile=cafile
             ).read().decode('utf-8')
-
-    def putRequest(self, endpoint, parameters):
-        '''Make a PUT request to teh toggl api at a certain enpoint and return the RAW page data (usually JSON)'''
-        data = json.JSONEncoder().encode(parameters)
-        binary_data = data.encode('utf-8')
-        # make request and read the response
-        return urlopen(
-            Request(endpoint, data=binary_data, headers=self.headers, method='PUT'), cafile=cafile
-        ).read().decode('utf-8')
 
     # ---------------------------------
     # Methods for managing Time Entries
@@ -480,5 +471,5 @@ class Toggl():
         data['client']['name'] = name
         data['client']['notes'] = notes
 
-        response = self.putRequest(Endpoints.CLIENTS + '/{0}'.format(id), parameters=data)
+        response = self.postRequest(Endpoints.CLIENTS + '/{0}'.format(id), parameters=data, method='PUT')
         return self.decodeJSON(response)


### PR DESCRIPTION
- Added a createClient function
- Added an updateClient function
- Added a deleteClient function
- Extended parameters on the postRequest function 
  Some of the Toggl API calls require a PUT or DELETE method rather than a POST.
  Added an additional parameter to the postRequest to allow this to be
  achieved by a single function rather than adding additional functions.
  New parameter defaults to PUT and all existing functions tested to
  ensure no changes in behaviour