### PR TITLE
added getTimeEntries method

### DIFF
--- a/toggl/TogglPy.py
+++ b/toggl/TogglPy.py
@@ -218,9 +218,21 @@ class Toggl():
 
         return json.loads(urlopen(request).read())
 
+    def getTimeEntries(self, start=None, end=None):
+        """
+        Return the time entrys.  Limited to 1000 entries returned.
+        :param start: Datetime at start of range to pull entries
+        :param end: Datetime at end of range to pull entries
+        """
+        params = {}
+        if start and end:
+            p = {'start_date':start.isoformat(), 'end_date':end.isoformat()}
+        return self.request(Endpoints.TIME_ENTRIES, parameters=params)
+
     # ----------------------------------
     # Methods for getting workspace data
     # ----------------------------------
+
     def getWorkspaces(self):
         '''return all the workspaces for a user'''
         return self.request(Endpoints.WORKSPACES)


### PR DESCRIPTION
I created a getTimeEntries method using the TIME_ENTRIES endpoint.  It takes a datetime start and end or returns the last 9 days if dates are not supplied.  