### PR TITLE
Add billable optional argument to time entry creation

### DIFF
--- a/toggl/TogglPy.py
+++ b/toggl/TogglPy.py
@@ -156,8 +156,9 @@ class Toggl():
         response = self.postRequest(Endpoints.STOP_TIME(entryid))
         return self.decodeJSON(response)
 
-    def createTimeEntry(self, hourduration, billable, description=None, projectid=None, projectname=None,
-                        taskid=None, clientname=None, year=None, month=None, day=None, hour=None):
+    def createTimeEntry(self, hourduration, description=None, projectid=None, projectname=None,
+                        taskid=None, clientname=None, year=None, month=None, day=None, hour=None,
+                        billable=False):
         """
         Creating a custom time entry, minimum must is hour duration and project param
         :param hourduration:

--- a/toggl/TogglPy.py
+++ b/toggl/TogglPy.py
@@ -156,7 +156,7 @@ class Toggl():
         response = self.postRequest(Endpoints.STOP_TIME(entryid))
         return self.decodeJSON(response)
 
-    def createTimeEntry(self, hourduration, description=None, projectid=None, projectname=None,
+    def createTimeEntry(self, hourduration, billable, description=None, projectid=None, projectname=None,
                         taskid=None, clientname=None, year=None, month=None, day=None, hour=None):
         """
         Creating a custom time entry, minimum must is hour duration and project param
@@ -201,6 +201,7 @@ class Toggl():
         data['time_entry']['duration'] = hourduration * 3600
         data['time_entry']['pid'] = projectid
         data['time_entry']['created_with'] = 'NAME'
+        data['time_entry']['billable'] = billable
 
         response = self.postRequest(Endpoints.TIME_ENTRIES, parameters=data)
         return self.decodeJSON(response)


### PR DESCRIPTION
Default set to `False` so it shouldn't break existing workflows.