### PR TITLE
Fix: change current time entry HTTP method to GET

### DIFF
--- a/toggl/TogglPy.py
+++ b/toggl/TogglPy.py
@@ -148,7 +148,7 @@ class Toggl():
 
     def currentRunningTimeEntry(self):
         '''Gets the Current Time Entry'''
-        response = self.request(Endpoints.CURRENT_RUNNING_TIME)
+        response = self.request(Endpoints.CURRENT_RUNNING_TIME, method="GET")
         return response
 
     def stopTimeEntry(self, entryid):


### PR DESCRIPTION
According to the [docs](https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md#get-running-time-entry) we should use a `GET` -instead of a `POST`- to get the currently running time entry.